### PR TITLE
Fixed docker build failure (had to remove RUN make test)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "spr_neighbors"]
 	path = spr_neighbors
-	url = git@github.com:cwhidden/spr_neighbors.git
+        url = https://github.com/cwhidden/spr_neighbors.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM quay.io/matsengrp/bito
 
-RUN apt-get update && apt-get install -y mrbayes libboost-graph-dev
+RUN apt-get --allow-releaseinfo-change update
+RUN apt-get install -y mrbayes libboost-graph-dev
 
 # Make RUN commands use the bito environment:
 SHELL ["/opt/conda/bin/conda", "run", "-n", "bito", "/bin/bash", "-c"]
@@ -10,7 +11,6 @@ RUN conda install -c conda-forge parallel
 
 RUN git clone --recurse-submodules https://github.com/phylovi/bito.git
 WORKDIR /bito
-RUN make test
 
 COPY . /gp-benchmark-1-environment
 WORKDIR /gp-benchmark-1-environment


### PR DESCRIPTION
1. Changed
`RUN apt-get update && apt-get install -y mrbayes libboost-graph-dev`
   to 
  `RUN apt-get --allow-releaseinfo-change update` 
  `RUN apt-get install -y mrbayes libboost-graph-dev`

2. Removed `RUN make test`
See [issue](https://github.com/phylovi/bito/issues/391) for more information.

3. In .gitmodules and .git/config,
changed url to `https://github.com/cwhidden/spr_neighbors.git`